### PR TITLE
Support WebXR Viewer

### DIFF
--- a/cesium.html
+++ b/cesium.html
@@ -4,7 +4,7 @@
     <title>Web AR Experiment</title>
     <script src="https://aframe.io/releases/0.7.1/aframe.min.js"></script>
     <script src="https://google-ar.github.io/three.ar.js/dist/three.ar.js"></script>
-    <script src="https://rawgit.com/chenzlabs/aframe-ar/827e9db/dist/aframe-ar.min.js"></script>
+    <script src="https://rawgit.com/chenzlabs/aframe-ar/webxrviewer-raycaster/dist/aframe-ar.min.js"></script>
     <script src="https://cdn.rawgit.com/donmccurdy/aframe-extras/cfe5f316/dist/aframe-extras.js"></script>
     <script type="text/javascript">
       AFRAME.registerComponent('shadow-material', {

--- a/cesium.html
+++ b/cesium.html
@@ -4,7 +4,7 @@
     <title>Web AR Experiment</title>
     <script src="https://aframe.io/releases/0.7.1/aframe.min.js"></script>
     <script src="https://google-ar.github.io/three.ar.js/dist/three.ar.js"></script>
-    <script src="https://rawgit.com/chenzlabs/aframe-ar/webxrviewer-raycaster/dist/aframe-ar.min.js"></script>
+    <script src="https://rawgit.com/chenzlabs/aframe-ar/73c5e83/dist/aframe-ar.min.js"></script>
     <script src="https://cdn.rawgit.com/donmccurdy/aframe-extras/cfe5f316/dist/aframe-extras.js"></script>
     <script type="text/javascript">
       AFRAME.registerComponent('shadow-material', {

--- a/cesium.html
+++ b/cesium.html
@@ -15,6 +15,8 @@
         }
       });
     </script>
+    <!-- Prevent touch causing flicker on iOS. -->
+    <style> * { -webkit-tap-highlight-color: rgba(0,0,0,0); } </style>        
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <script src="https://aframe.io/releases/0.7.1/aframe.min.js"></script>
     <script src="https://cdn.rawgit.com/donmccurdy/aframe-extras/cfe5f316/dist/aframe-extras.js"></script>
     <script src="https://google-ar.github.io/three.ar.js/dist/three.ar.js"></script>
-    <script src="https://rawgit.com/chenzlabs/aframe-ar/827e9db/dist/aframe-ar.min.js"></script>
+    <script src="https://rawgit.com/chenzlabs/aframe-ar/webxrviewer-raycaster/dist/aframe-ar.min.js"></script>
     <script>
         AFRAME.registerComponent('shadow-material', {
             init: function () {

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
                 }
             });
         }
-/*
+
         function onCommand(results) {
             recognition.start();
             for (const result of results) {
@@ -171,7 +171,7 @@
         recognition.onresult = ({results}) => onCommand(results);
         recognition.onerror = () => setTimeout(() => recognition.start(), 500);
         recognition.start();
-*/
+
         scene.addEventListener('loaded', onceSceneLoaded);
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
 
 <body>
     <a-scene ar>
+        <!-- Specify raycaster="objects:none" to avoid intersections with A-Frame entities like the fox. -->
         <a-camera user-height="0" cursor="fuse:false" ar-raycaster raycaster="objects:none"></a-camera>
         <a-entity id="walker" position="0 0 -5" visible="false">
             <a-entity gltf-model="models/fox.glb" scale="0.5 0.5 0.5" id="fox" animation-mixer="clip:Fox_Idle" shadow="cast: true">

--- a/index.html
+++ b/index.html
@@ -80,11 +80,11 @@
                     marker.setAttribute('visible', true);
                 }
             });
-
+/*
             raycaster.addEventListener('raycaster-intersection-cleared', function (event) {
                 marker.setAttribute('visible', false);
             });
-
+*/
             const { stringify } = AFRAME.utils.coordinates;
 
             let lastEvent = null;

--- a/index.html
+++ b/index.html
@@ -80,13 +80,14 @@
                 if (intersection) {
                     marker.setAttribute('position', intersection.point);
                     marker.setAttribute('visible', true);
+                    marker.setAttribute('color', 'green');
                 }
             });
-/*
+
             raycaster.addEventListener('raycaster-intersection-cleared', function (event) {
-                marker.setAttribute('visible', false);
+                marker.setAttribute('color', 'red');
             });
-*/
+
             const { stringify } = AFRAME.utils.coordinates;
 
             let lastEvent = null;
@@ -114,7 +115,7 @@
                     animation.addEventListener('animationend',
                         () => fox.setAttribute('animation-mixer', { clip: idleAnimation }));
                     marker.setAttribute('color', 'blue');
-                    setTimeout(() => marker.setAttribute('color', 'red'), 350);
+                    setTimeout(() => marker.setAttribute('color', 'green'), 350);
                     walker.appendChild(animation);
                 }
             });

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <script src="https://aframe.io/releases/0.7.1/aframe.min.js"></script>
     <script src="https://cdn.rawgit.com/donmccurdy/aframe-extras/cfe5f316/dist/aframe-extras.js"></script>
     <script src="https://google-ar.github.io/three.ar.js/dist/three.ar.js"></script>
-    <script src="https://rawgit.com/chenzlabs/aframe-ar/webxrviewer-raycaster/dist/aframe-ar.min.js"></script>
+    <script src="https://rawgit.com/chenzlabs/aframe-ar/73c5e83/dist/aframe-ar.min.js"></script>
     <script>
         AFRAME.registerComponent('shadow-material', {
             init: function () {

--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
                 }
             });
         }
-
+/*
         function onCommand(results) {
             recognition.start();
             for (const result of results) {
@@ -167,7 +167,7 @@
         recognition.onresult = ({results}) => onCommand(results);
         recognition.onerror = () => setTimeout(() => recognition.start(), 500);
         recognition.start();
-
+*/
         scene.addEventListener('loaded', onceSceneLoaded);
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -165,12 +165,16 @@
             }
         }
 
+        try {
+            
         recognition = new webkitSpeechRecognition();
         recognition.continuous = true;
         recognition.maxAlternatives = 5;
         recognition.onresult = ({results}) => onCommand(results);
         recognition.onerror = () => setTimeout(() => recognition.start(), 500);
         recognition.start();
+
+        } catch (err) { console.error(err.message); }
 
         scene.addEventListener('loaded', onceSceneLoaded);
     </script>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
             }
         });
     </script>
+    <!-- Prevent touch causing flicker on iOS. -->
+    <style> * { -webkit-tap-highlight-color: rgba(0,0,0,0); } </style>        
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
 <body>
     <a-scene ar>
-        <a-camera user-height="0" cursor="fuse:false" ar-raycaster raycaster></a-camera>
+        <a-camera user-height="0" cursor="fuse:false" ar-raycaster raycaster="objects:none"></a-camera>
         <a-entity id="walker" position="0 0 -5" visible="false">
             <a-entity gltf-model="models/fox.glb" scale="0.5 0.5 0.5" id="fox" animation-mixer="clip:Fox_Idle" shadow="cast: true">
             </a-entity>
@@ -74,7 +74,7 @@
             activateFox();
 
             raycaster.addEventListener('raycaster-intersection', function (event) {
-                const intersection = event.detail.intersections.find(i => i.object.type === 'Scene');
+                const intersection = event.detail.intersections[0]; //.find(i => i.object.type === 'Scene');
                 if (intersection) {
                     marker.setAttribute('position', intersection.point);
                     marker.setAttribute('visible', true);


### PR DESCRIPTION
This PR adds support for Mozilla's WebXR Viewer app on iOS.

Note small change to behavior (rather than invisible cursor when not OK, this PR makes it green ball = OK to click, red ball = not OK to click -- there appears to be an out of order issue on WebXR Viewer that excessively hides the ball otherwise)

Squashing the merge is highly encouraged :-)